### PR TITLE
Additional logging at the beginning and end of handler

### DIFF
--- a/src/main/scala/com/gu/octopusthrift/Lambda.scala
+++ b/src/main/scala/com/gu/octopusthrift/Lambda.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.kinesis.model.Record
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.KinesisEvent
 import com.gu.flexibleoctopus.model.thrift._
-import com.gu.octopusthrift.aws.{ CustomMetrics, Kinesis, Metrics, SQS }
+import com.gu.octopusthrift.aws.{ CustomMetrics, DeadLetterQueue, Kinesis, Metrics }
 import com.gu.octopusthrift.models._
 import com.gu.octopusthrift.services.Logging
 import com.gu.octopusthrift.services.PayloadValidator.{ isValidBundle, validatePayload }
@@ -14,9 +14,7 @@ import play.api.libs.json._
 import scala.jdk.CollectionConverters._
 import scala.util.{ Failure, Success, Try }
 
-object Lambda extends Logging with CustomMetrics {
-
-  val deadLetterQueue = new SQS(Config.apply)
+object Lambda extends Logging with CustomMetrics with DeadLetterQueue {
 
   def handler(lambdaInput: KinesisEvent, context: Context): Unit = {
     val records: List[Record] = lambdaInput.getRecords.asScala.map(_.getKinesis).toList

--- a/src/main/scala/com/gu/octopusthrift/aws/CloudWatch.scala
+++ b/src/main/scala/com/gu/octopusthrift/aws/CloudWatch.scala
@@ -14,6 +14,7 @@ object Metrics {
   val MissingMandatoryBundleData = "MissingMandatoryBundleData"
   val FailedThriftConversion = "FailedThriftConversion"
   val MissingExpectedPayloadData = "MissingExpectedPayloadData"
+  val InvalidOctopusPayload = "InvalidOctopusPayload"
 }
 
 class CloudWatch(config: Config) extends Logging {
@@ -24,9 +25,7 @@ class CloudWatch(config: Config) extends Logging {
 
   def publishMetricEvent(metric: String): Unit = {
 
-    val dimension = new Dimension()
-      .withName("Stage")
-      .withValue(config.stage);
+    val dimension = new Dimension().withName("Stage").withValue(config.stage);
 
     val datum = new MetricDatum()
       .withMetricName(metric)
@@ -34,9 +33,7 @@ class CloudWatch(config: Config) extends Logging {
       .withValue(1)
       .withDimensions(dimension)
 
-    val request = new PutMetricDataRequest()
-      .withNamespace("OctopusLambda")
-      .withMetricData(datum)
+    val request = new PutMetricDataRequest().withNamespace("OctopusLambda").withMetricData(datum)
 
     try {
       val result = cloudWatchClient.putMetricData(request)

--- a/src/main/scala/com/gu/octopusthrift/aws/DeadLetterQueue.scala
+++ b/src/main/scala/com/gu/octopusthrift/aws/DeadLetterQueue.scala
@@ -1,0 +1,7 @@
+package com.gu.octopusthrift.aws
+
+import com.gu.octopusthrift.Config
+
+trait DeadLetterQueue {
+  val deadLetterQueue = new SQS(Config.apply)
+}

--- a/src/main/scala/com/gu/octopusthrift/services/PayloadValidator.scala
+++ b/src/main/scala/com/gu/octopusthrift/services/PayloadValidator.scala
@@ -12,7 +12,10 @@ object PayloadValidator extends Logging {
       case Success(json) =>
         json.validate[OctopusPayload] match {
           case JsSuccess(payload, _) => Some(payload)
-          case _: JsError            => None
+          case _: JsError => {
+            logger.info(s"Payload does not match OctopusPayload model: $json")
+            None
+          }
         }
       case _ => None
     }

--- a/src/main/scala/com/gu/octopusthrift/services/PayloadValidator.scala
+++ b/src/main/scala/com/gu/octopusthrift/services/PayloadValidator.scala
@@ -1,11 +1,12 @@
 package com.gu.octopusthrift.services
 
+import com.gu.octopusthrift.aws.{ CustomMetrics, DeadLetterQueue, Metrics }
 import com.gu.octopusthrift.models._
 import play.api.libs.json._
 
 import scala.util.{ Success, Try }
 
-object PayloadValidator extends Logging {
+object PayloadValidator extends Logging with CustomMetrics with DeadLetterQueue {
 
   def validatePayload(decodedData: Array[Byte]): Option[OctopusPayload] = {
     Try(Json.parse(decodedData)) match {
@@ -14,6 +15,8 @@ object PayloadValidator extends Logging {
           case JsSuccess(payload, _) => Some(payload)
           case _: JsError => {
             logger.info(s"Payload does not match OctopusPayload model: $json")
+            deadLetterQueue.sendMessage(json)
+            cloudWatch.publishMetricEvent(Metrics.InvalidOctopusPayload)
             None
           }
         }


### PR DESCRIPTION
Our logs suggest that we are receiving some payloads that do not match our expected models, but we don't have any logging to confirm this. These are instances when the lambda is invoked and throws no errors, but does not log (aside from the default lambda log events that record duration, memory used, etc.) or put anything to the Thrift Kinesis stream.

