### PR TITLE
Adjust filtering for body text

### DIFF
--- a/src/main/scala/com/gu/octopusthrift/models/OctopusArticle.scala
+++ b/src/main/scala/com/gu/octopusthrift/models/OctopusArticle.scala
@@ -5,7 +5,6 @@ import java.util.concurrent.TimeUnit
 import com.gu.flexibleoctopus.model.thrift._
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{ DateTime, DateTimeZone }
-import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
 import scala.util.{ Success, Try }
@@ -26,7 +25,7 @@ case class OctopusArticle(
   ischeckedout: String,
   status: String,
   attached_to: Option[Int],
-  on_pages: Option[String]) {
+  on_pages: Option[String]) extends Ordered[OctopusArticle] {
 
   def lastModifiedEpoch: Long =
     TimeUnit.MILLISECONDS.toSeconds(
@@ -43,6 +42,8 @@ case class OctopusArticle(
   }
 
   def as[T](implicit f: OctopusArticle => T): T = f(this)
+
+  override def compare(that: OctopusArticle): Int = this.object_number compareTo that.object_number
 }
 
 object OctopusArticle {

--- a/src/main/scala/com/gu/octopusthrift/services/ArticleFinder.scala
+++ b/src/main/scala/com/gu/octopusthrift/services/ArticleFinder.scala
@@ -20,29 +20,31 @@ object ArticleFinder extends Logging {
 
   // Prefer articles that are labelled both, then web, then print
   private def articlesForPreferredDestination(
-      articles: Map[String, Array[OctopusArticle]]
-  ): Array[OctopusArticle] = {
-    (Try(articles(ForBoth)), Try(articles(ForWeb)), Try(articles(ForPrint))) match {
-      case (Success(forBoth), _, _)                    => forBoth
-      case (Failure(_), Success(forWeb), _)            => forWeb
-      case (Failure(_), Failure(_), Success(forPrint)) => forPrint
-      case _                                           => Array.empty[OctopusArticle]
+    articles: Map[String, Array[OctopusArticle]]): Array[OctopusArticle] = {
+    val forBoth = Try(articles(ForBoth))
+    val forWeb = Try(articles(ForWeb))
+    val forPrint = Try(articles(ForPrint))
+
+    (forBoth, forWeb, forPrint) match {
+      case (Success(both), _, _) => both
+      case (Failure(_), Success(web), _) => web
+      case (Failure(_), Failure(_), Success(print)) => print
+      case _ => Array.empty[OctopusArticle]
     }
   }
 
   // Prefer Body Text, then Panel Text, then Tabular Text
   private def articlesOfPreferredObjectType(
-      articles: Map[String, Array[OctopusArticle]]
-  ): Array[OctopusArticle] = {
+    articles: Map[String, Array[OctopusArticle]]): Array[OctopusArticle] = {
     val bodyText = Try(articles(BodyText))
     val panelText = Try(articles(PanelText))
     val tabularText = Try(articles(TabularText))
 
     (bodyText, panelText, tabularText) match {
-      case (Success(bodyTexts), _, _)                      => bodyTexts
-      case (Failure(_), Success(panelTexts), _)            => panelTexts
+      case (Success(bodyTexts), _, _) => bodyTexts
+      case (Failure(_), Success(panelTexts), _) => panelTexts
       case (Failure(_), Failure(_), Success(tabularTexts)) => tabularTexts
-      case _                                               => Array.empty[OctopusArticle]
+      case _ => Array.empty[OctopusArticle]
     }
   }
 
@@ -54,21 +56,28 @@ object ArticleFinder extends Logging {
    */
   def findBodyText(bundle: OctopusBundle): Option[OctopusArticle] = {
 
+    // Given a bundles worth of articles, pick only the ones that are Body Text, Panel Text or Tabular Text
     val onlyBodyTextArticles: Array[OctopusArticle] =
       bundle.articles
         .map(a => a.copy(object_type = cleanObjectType(a.object_type)))
         .filter(a => bodyTextObjects.contains(a.object_type))
 
     if (onlyBodyTextArticles.isEmpty)
+      // There are no suitable articles
       None
     else if (onlyBodyTextArticles.length == 1)
+      // There's only one suitable article
       onlyBodyTextArticles.headOption
     else {
-      val groupedByDestination = onlyBodyTextArticles.groupBy(_.for_publication.toLowerCase)
+      // Given a number of suitable articles, group them by their publication destination
+      val groupedByDestination: Map[String, Array[OctopusArticle]] =
+        onlyBodyTextArticles.groupBy(_.for_publication.toLowerCase)
 
-      val forPreferredDestinationAndGroupedByType =
+      // Pick the available articles for the destination we prefer the most, then group them by object type
+      val forPreferredDestinationAndGroupedByType: Map[String, Array[OctopusArticle]] =
         articlesForPreferredDestination(groupedByDestination).groupBy(_.object_type)
 
+      // Pick the article with the most preferred object type and the lowest object number
       articlesOfPreferredObjectType(forPreferredDestinationAndGroupedByType).sorted.headOption
     }
   }

--- a/src/test/scala/services/ArticleFinderSpec.scala
+++ b/src/test/scala/services/ArticleFinderSpec.scala
@@ -8,6 +8,23 @@ import com.gu.octopusthrift.models._
 
 class ArticleFinderSpec extends AnyWordSpec with Matchers {
 
+  def createTestArticle(forPublication: String, objectType: String, objectNumber: Int) =
+    OctopusArticle(
+      1233,
+      "article.t0",
+      forPublication,
+      "n",
+      objectType,
+      objectNumber,
+      "202006241200",
+      None,
+      "N",
+      "Writers",
+      Some(1000),
+      Some("1"))
+
+  def createTestBundle(articles: Array[OctopusArticle]) = OctopusBundle(101, "", "", Some(""), "", articles)
+
   "ArticleFinder" when {
     "findBodyText is called" should {
       "retrieve the body text when it's present" in {
@@ -33,283 +50,60 @@ class ArticleFinderSpec extends AnyWordSpec with Matchers {
         assert(ArticleFinder.findBodyText(articleWithMultipleBodyTexts).contains(expectedArticle))
         assert(ArticleFinder.findBodyText(articleWithBodyPanelAndTabularTexts).contains(expectedArticle))
       }
-      "prefer both to web and print" in {
-        val articleForWeb = OctopusArticle(
-          1233,
-          "article.t0",
-          "w",
-          "n",
-          "Body Text",
-          1,
-          "202006241200",
-          None,
-          "N",
-          "Writers",
-          Some(1000),
-          Some("1"))
-        val articleForPrint = OctopusArticle(
-          1234,
-          "article.t0",
-          "p",
-          "n",
-          "Body Text",
-          1,
-          "202006241200",
-          None,
-          "N",
-          "Writers",
-          Some(1000),
-          Some("1"))
-        val articleForBoth = OctopusArticle(
-          1233,
-          "article.t0",
-          "b",
-          "n",
-          "Body Text",
-          1,
-          "202006241200",
-          None,
-          "N",
-          "Writers",
-          Some(1000),
-          Some("1"))
-
+      "prefer 'for_publication' of both to web and print" in {
+        val articleForWeb = createTestArticle("w", "Body Text", 1)
+        val articleForPrint = createTestArticle("p", "Body Text", 1)
+        val articleForBoth = createTestArticle("b", "Body Text", 1)
         val articles = Array(articleForPrint, articleForWeb, articleForBoth)
 
-        val bundle = OctopusBundle(101, "", "", Some(""), "", articles)
-
-        assert(ArticleFinder.findBodyText(bundle).contains(articleForBoth))
+        assert(ArticleFinder.findBodyText(createTestBundle(articles)).contains(articleForBoth))
       }
-      "prefer web to print" in {
-        val articleForWeb = OctopusArticle(
-          1233,
-          "article.t0",
-          "w",
-          "n",
-          "Body Text",
-          1,
-          "202006241200",
-          None,
-          "N",
-          "Writers",
-          Some(1000),
-          Some("1"))
-        val articleForPrint = OctopusArticle(
-          1234,
-          "article.t0",
-          "p",
-          "n",
-          "Body Text",
-          1,
-          "202006241200",
-          None,
-          "N",
-          "Writers",
-          Some(1000),
-          Some("1"))
-
+      "prefer 'for_publication' of web to print" in {
+        val articleForWeb = createTestArticle("w", "Body Text", 1)
+        val articleForPrint = createTestArticle("p", "Body Text", 1)
         val articles = Array(articleForPrint, articleForWeb)
 
-        val bundle = OctopusBundle(101, "", "", Some(""), "", articles)
-
-        assert(ArticleFinder.findBodyText(bundle).contains(articleForWeb))
+        assert(ArticleFinder.findBodyText(createTestBundle(articles)).contains(articleForWeb))
       }
-      "prefer Body Text to other types" in {
-        val articleObjectOne = OctopusArticle(
-          1233,
-          "article.t0",
-          "w",
-          "n",
-          "Tabular Text",
-          1,
-          "202006241200",
-          None,
-          "N",
-          "Writers",
-          Some(1000),
-          Some("1"))
-        val articleObjectTwo = OctopusArticle(
-          1234,
-          "article.t0",
-          "w",
-          "n",
-          "Body Text [Ruled]",
-          2,
-          "202006241200",
-          None,
-          "N",
-          "Writers",
-          Some(1000),
-          Some("1"))
-        val articleObjectThree = OctopusArticle(
-          1234,
-          "article.t0",
-          "w",
-          "n",
-          "Panel Text",
-          1,
-          "202006241200",
-          None,
-          "N",
-          "Writers",
-          Some(1000),
-          Some("1"))
-        val articleObjectFour = OctopusArticle(
-          1233,
-          "article.t0",
-          "w",
-          "n",
-          "Headline",
-          1,
-          "202006241200",
-          None,
-          "N",
-          "Writers",
-          Some(1000),
-          Some("1"))
-
+      "prefer 'object_type' of Body Text to other types" in {
+        val articleObjectOne = createTestArticle("w", "Tabular Text", 1)
+        val articleObjectTwo = createTestArticle("w", "Body Text [Ruled]", 1)
+        val articleObjectThree = createTestArticle("w", "Panel Text", 1)
+        val articleObjectFour = createTestArticle("w", "Headline", 1)
         val articles = Array(articleObjectFour, articleObjectTwo, articleObjectThree, articleObjectOne)
 
-        val bundle = OctopusBundle(101, "", "", Some(""), "", articles)
-
-        assert(ArticleFinder.findBodyText(bundle).contains(articleObjectTwo.copy(object_type = "Body Text")))
+        assert(
+          ArticleFinder
+            .findBodyText(createTestBundle(articles))
+            .contains(articleObjectTwo.copy(object_type = "Body Text")))
       }
-      "prefer Panel Text to Tabular types" in {
-        val tabularArticleForWeb = OctopusArticle(
-          1233,
-          "article.t0",
-          "w",
-          "n",
-          "Tabular Text",
-          1,
-          "202006241200",
-          None,
-          "N",
-          "Writers",
-          Some(1000),
-          Some("1"))
-        val panelArticle = OctopusArticle(
-          1234,
-          "article.t0",
-          "w",
-          "n",
-          "Panel Text",
-          2,
-          "202006241200",
-          None,
-          "N",
-          "Writers",
-          Some(1000),
-          Some("1"))
-        val tabularArticleForPrint = OctopusArticle(
-          1234,
-          "article.t0",
-          "p",
-          "n",
-          "Tabular Text",
-          1,
-          "202006241200",
-          None,
-          "N",
-          "Writers",
-          Some(1000),
-          Some("1"))
-
+      "prefer 'object_type' of Panel Text to Tabular types" in {
+        val tabularArticleForWeb = createTestArticle("w", "Tabular Text", 1)
+        val panelArticle = createTestArticle("w", "Panel Text", 1)
+        val tabularArticleForPrint = createTestArticle("p", "Tabular Text", 1)
         val articles = Array(tabularArticleForPrint, panelArticle, tabularArticleForWeb)
 
-        val bundle = OctopusBundle(101, "", "", Some(""), "", articles)
-
-        assert(ArticleFinder.findBodyText(bundle).contains(panelArticle))
+        assert(ArticleFinder.findBodyText(createTestBundle(articles)).contains(panelArticle))
       }
-      "prefer Tabular if there is no other option" in {
-        val articleForPrint = OctopusArticle(
-          1233,
-          "article.t0",
-          "p",
-          "n",
-          "Tabular Text",
-          1,
-          "202006241200",
-          None,
-          "N",
-          "Writers",
-          Some(1000),
-          Some("1"))
-        val articleForWeb = OctopusArticle(
-          1234,
-          "article.t0",
-          "w",
-          "n",
-          "Tabular Text",
-          2,
-          "202006241200",
-          None,
-          "N",
-          "Writers",
-          Some(1000),
-          Some("1"))
-
+      "prefer 'object_type' of Tabular if there is no other option" in {
+        val articleForPrint = createTestArticle("p", "Tabular Text", 1)
+        val articleForWeb = createTestArticle("w", "Tabular Text", 1)
         val articles = Array(articleForPrint, articleForWeb)
 
-        val bundle = OctopusBundle(101, "", "", Some(""), "", articles)
-
-        assert(ArticleFinder.findBodyText(bundle).contains(articleForWeb))
+        assert(ArticleFinder.findBodyText(createTestBundle(articles)).contains(articleForWeb))
       }
       "select the only option if only one available" in {
-        val articleForPrint = OctopusArticle(
-          1233,
-          "article.t0",
-          "p",
-          "n",
-          "Tabular Text",
-          1,
-          "202006241200",
-          None,
-          "N",
-          "Writers",
-          Some(1000),
-          Some("1"))
-
+        val articleForPrint = createTestArticle("p", "Tabular Text", 1)
         val articles = Array(articleForPrint)
 
-        val bundle = OctopusBundle(101, "", "", Some(""), "", articles)
-
-        assert(ArticleFinder.findBodyText(bundle).contains(articleForPrint))
+        assert(ArticleFinder.findBodyText(createTestBundle(articles)).contains(articleForPrint))
       }
       "select the option with the lowest object number" in {
-        val articleForPrint = OctopusArticle(
-          1233,
-          "article.t0",
-          "p",
-          "n",
-          "Tabular Text",
-          1,
-          "202006241200",
-          None,
-          "N",
-          "Writers",
-          Some(1000),
-          Some("1"))
-
-        val articleForPrintSecond = OctopusArticle(
-          1233,
-          "article.t0",
-          "p",
-          "n",
-          "Tabular Text",
-          2,
-          "202006241200",
-          None,
-          "N",
-          "Writers",
-          Some(1000),
-          Some("1"))
-
+        val articleForPrint = createTestArticle("p", "Tabular Text", 1)
+        val articleForPrintSecond = createTestArticle("p", "Tabular Text", 2)
         val articles = Array(articleForPrintSecond, articleForPrint)
 
-        val bundle = OctopusBundle(101, "", "", Some(""), "", articles)
-
-        assert(ArticleFinder.findBodyText(bundle).contains(articleForPrint))
+        assert(ArticleFinder.findBodyText(createTestBundle(articles)).contains(articleForPrint))
       }
     }
   }

--- a/src/test/scala/services/ArticleFinderSpec.scala
+++ b/src/test/scala/services/ArticleFinderSpec.scala
@@ -13,19 +13,15 @@ class ArticleFinderSpec extends AnyWordSpec with Matchers {
       "retrieve the body text when it's present" in {
         val exampleJson = TestUtils.readJson(s"/example.json").as[OctopusBundle]
         val expectedArticle = TestUtils.readJson(s"/article.json").as[OctopusArticle]
-        assert(ArticleFinder.findBodyText(exampleJson) == Some(expectedArticle))
+        assert(ArticleFinder.findBodyText(exampleJson).contains(expectedArticle))
       }
       "return None when there's no body text found" in {
         val exampleJson = TestUtils.readJson(s"/exampleWithoutBodyText.json").as[OctopusBundle]
-        assert(ArticleFinder.findBodyText(exampleJson) == None)
+        assert(ArticleFinder.findBodyText(exampleJson).isEmpty)
       }
       "return None when there is not a complete article" in {
         val exampleJson = TestUtils.readJson(s"/exampleWithMissingArticleFields.json").as[OctopusBundle]
-        assert(ArticleFinder.findBodyText(exampleJson) == None)
-      }
-      "return None when there is a body text, but it isn't for web" in {
-        val exampleJson = TestUtils.readJson(s"/exampleWithNoWebPublication.json").as[OctopusBundle]
-        assert(ArticleFinder.findBodyText(exampleJson) == None)
+        assert(ArticleFinder.findBodyText(exampleJson).isEmpty)
       }
       "retrieve the primary body text when there is more than one possible body text" in {
         val articleWithMultipleBodyTexts =
@@ -34,8 +30,286 @@ class ArticleFinderSpec extends AnyWordSpec with Matchers {
           TestUtils.readJson(s"/exampleWithMultipleBodyPanelAndTabular.json").as[OctopusBundle]
         val expectedArticle = TestUtils.readJson(s"/article.json").as[OctopusArticle]
 
-        assert(ArticleFinder.findBodyText(articleWithMultipleBodyTexts) == Some(expectedArticle))
-        assert(ArticleFinder.findBodyText(articleWithBodyPanelAndTabularTexts) == Some(expectedArticle))
+        assert(ArticleFinder.findBodyText(articleWithMultipleBodyTexts).contains(expectedArticle))
+        assert(ArticleFinder.findBodyText(articleWithBodyPanelAndTabularTexts).contains(expectedArticle))
+      }
+      "prefer both to web and print" in {
+        val articleForWeb = OctopusArticle(
+          1233,
+          "article.t0",
+          "w",
+          "n",
+          "Body Text",
+          1,
+          "202006241200",
+          None,
+          "N",
+          "Writers",
+          Some(1000),
+          Some("1"))
+        val articleForPrint = OctopusArticle(
+          1234,
+          "article.t0",
+          "p",
+          "n",
+          "Body Text",
+          1,
+          "202006241200",
+          None,
+          "N",
+          "Writers",
+          Some(1000),
+          Some("1"))
+        val articleForBoth = OctopusArticle(
+          1233,
+          "article.t0",
+          "b",
+          "n",
+          "Body Text",
+          1,
+          "202006241200",
+          None,
+          "N",
+          "Writers",
+          Some(1000),
+          Some("1"))
+
+        val articles = Array(articleForPrint, articleForWeb, articleForBoth)
+
+        val bundle = OctopusBundle(101, "", "", Some(""), "", articles)
+
+        assert(ArticleFinder.findBodyText(bundle).contains(articleForBoth))
+      }
+      "prefer web to print" in {
+        val articleForWeb = OctopusArticle(
+          1233,
+          "article.t0",
+          "w",
+          "n",
+          "Body Text",
+          1,
+          "202006241200",
+          None,
+          "N",
+          "Writers",
+          Some(1000),
+          Some("1"))
+        val articleForPrint = OctopusArticle(
+          1234,
+          "article.t0",
+          "p",
+          "n",
+          "Body Text",
+          1,
+          "202006241200",
+          None,
+          "N",
+          "Writers",
+          Some(1000),
+          Some("1"))
+
+        val articles = Array(articleForPrint, articleForWeb)
+
+        val bundle = OctopusBundle(101, "", "", Some(""), "", articles)
+
+        assert(ArticleFinder.findBodyText(bundle).contains(articleForWeb))
+      }
+      "prefer Body Text to other types" in {
+        val articleObjectOne = OctopusArticle(
+          1233,
+          "article.t0",
+          "w",
+          "n",
+          "Tabular Text",
+          1,
+          "202006241200",
+          None,
+          "N",
+          "Writers",
+          Some(1000),
+          Some("1"))
+        val articleObjectTwo = OctopusArticle(
+          1234,
+          "article.t0",
+          "w",
+          "n",
+          "Body Text [Ruled]",
+          2,
+          "202006241200",
+          None,
+          "N",
+          "Writers",
+          Some(1000),
+          Some("1"))
+        val articleObjectThree = OctopusArticle(
+          1234,
+          "article.t0",
+          "w",
+          "n",
+          "Panel Text",
+          1,
+          "202006241200",
+          None,
+          "N",
+          "Writers",
+          Some(1000),
+          Some("1"))
+        val articleObjectFour = OctopusArticle(
+          1233,
+          "article.t0",
+          "w",
+          "n",
+          "Headline",
+          1,
+          "202006241200",
+          None,
+          "N",
+          "Writers",
+          Some(1000),
+          Some("1"))
+
+        val articles = Array(articleObjectFour, articleObjectTwo, articleObjectThree, articleObjectOne)
+
+        val bundle = OctopusBundle(101, "", "", Some(""), "", articles)
+
+        assert(ArticleFinder.findBodyText(bundle).contains(articleObjectTwo.copy(object_type = "Body Text")))
+      }
+      "prefer Panel Text to Tabular types" in {
+        val tabularArticleForWeb = OctopusArticle(
+          1233,
+          "article.t0",
+          "w",
+          "n",
+          "Tabular Text",
+          1,
+          "202006241200",
+          None,
+          "N",
+          "Writers",
+          Some(1000),
+          Some("1"))
+        val panelArticle = OctopusArticle(
+          1234,
+          "article.t0",
+          "w",
+          "n",
+          "Panel Text",
+          2,
+          "202006241200",
+          None,
+          "N",
+          "Writers",
+          Some(1000),
+          Some("1"))
+        val tabularArticleForPrint = OctopusArticle(
+          1234,
+          "article.t0",
+          "p",
+          "n",
+          "Tabular Text",
+          1,
+          "202006241200",
+          None,
+          "N",
+          "Writers",
+          Some(1000),
+          Some("1"))
+
+        val articles = Array(tabularArticleForPrint, panelArticle, tabularArticleForWeb)
+
+        val bundle = OctopusBundle(101, "", "", Some(""), "", articles)
+
+        assert(ArticleFinder.findBodyText(bundle).contains(panelArticle))
+      }
+      "prefer Tabular if there is no other option" in {
+        val articleForPrint = OctopusArticle(
+          1233,
+          "article.t0",
+          "p",
+          "n",
+          "Tabular Text",
+          1,
+          "202006241200",
+          None,
+          "N",
+          "Writers",
+          Some(1000),
+          Some("1"))
+        val articleForWeb = OctopusArticle(
+          1234,
+          "article.t0",
+          "w",
+          "n",
+          "Tabular Text",
+          2,
+          "202006241200",
+          None,
+          "N",
+          "Writers",
+          Some(1000),
+          Some("1"))
+
+        val articles = Array(articleForPrint, articleForWeb)
+
+        val bundle = OctopusBundle(101, "", "", Some(""), "", articles)
+
+        assert(ArticleFinder.findBodyText(bundle).contains(articleForWeb))
+      }
+      "select the only option if only one available" in {
+        val articleForPrint = OctopusArticle(
+          1233,
+          "article.t0",
+          "p",
+          "n",
+          "Tabular Text",
+          1,
+          "202006241200",
+          None,
+          "N",
+          "Writers",
+          Some(1000),
+          Some("1"))
+
+        val articles = Array(articleForPrint)
+
+        val bundle = OctopusBundle(101, "", "", Some(""), "", articles)
+
+        assert(ArticleFinder.findBodyText(bundle).contains(articleForPrint))
+      }
+      "select the option with the lowest object number" in {
+        val articleForPrint = OctopusArticle(
+          1233,
+          "article.t0",
+          "p",
+          "n",
+          "Tabular Text",
+          1,
+          "202006241200",
+          None,
+          "N",
+          "Writers",
+          Some(1000),
+          Some("1"))
+
+        val articleForPrintSecond = OctopusArticle(
+          1233,
+          "article.t0",
+          "p",
+          "n",
+          "Tabular Text",
+          2,
+          "202006241200",
+          None,
+          "N",
+          "Writers",
+          Some(1000),
+          Some("1"))
+
+        val articles = Array(articleForPrintSecond, articleForPrint)
+
+        val bundle = OctopusBundle(101, "", "", Some(""), "", articles)
+
+        assert(ArticleFinder.findBodyText(bundle).contains(articleForPrint))
       }
     }
   }


### PR DESCRIPTION
## What does this change?
This PR changes the way that we select which is the most important body text `OctopusArticle` in an `OctopusBundle`, and consequently which body text becomes part of the Thrift `StoryBundle` that is passed to Composer and/or Workflow. The rules we ought to follow (as outlined on [the Trello card](https://trello.com/c/7Re5O5Ju/273-modify-logic-on-how-we-pick-the-body-text-from-composer) by @blishen and @hoyla): 
> This is how we pick which one we care about.
> 
> We identify "source" components as having a component type of Body Text, Panel Text, or Tabular Text
> 
> Discarding any information that might appear in square brackets afterwards. We take the list of "text" elements.
> 
> 1. If some are print and some are web/both, discard the print ones
> 2. If we still have more than one and the types are mixed discard all tabular components
> 3. If we still have more than one and the types are mixed discard all panel components
> 4. If we still have more than one, pick the one with the lowest number. 

The key changes to the `ArticleFinder` implementation are that:
1) we no longer discard articles that are marked `for_publication` in print
2) we establish that Panel Text is preferrable to Tabular Text

## How can we measure success?
We should select the most appropriate body text article in any given situation.
