### PR TITLE
Ignore for_publication values that are not important to us

### DIFF
--- a/src/test/scala/services/ArticleFinderSpec.scala
+++ b/src/test/scala/services/ArticleFinderSpec.scala
@@ -65,6 +65,13 @@ class ArticleFinderSpec extends AnyWordSpec with Matchers {
 
         assert(ArticleFinder.findBodyText(createTestBundle(articles)).contains(articleForWeb))
       }
+      "ignore 'for_publication' values of 'n' and 'y'" in {
+        val articleOne = createTestArticle("y", "Body Text", 1)
+        val articleTwo = createTestArticle("n", "Body Text", 1)
+        val articles = Array(articleOne, articleTwo)
+
+        assert(ArticleFinder.findBodyText(createTestBundle(articles)).isEmpty)
+      }
       "prefer 'object_type' of Body Text to other types" in {
         val articleObjectOne = createTestArticle("w", "Tabular Text", 1)
         val articleObjectTwo = createTestArticle("w", "Body Text [Ruled]", 1)


### PR DESCRIPTION
## What does this change?
Creates an explicit set of publication destinations that we are interested in. In addition to the three values that we list in `validPublicationDestinations`, there are also possible destinations of `n` and `y`. When it comes to finding the primary body text in a bundle, we want to ignore articles with these values.

## How can we measure success?
No more bundles added to the dead letter queue as a result of having unexpected `for_publication` values.

