### PR TITLE
Incorporate the new lastModifiedBy field in Article

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.1.2" % "test",
   "com.typesafe.play" %% "play-json" % "2.8.1",
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.11.0",
-  "com.gu" %% "flexible-octopus-model" % "0.2.0",
+  "com.gu" %% "flexible-octopus-model" % "0.4.0",
   "org.apache.thrift" % "libthrift" % "0.13.0",
   "com.twitter" %% "scrooge-core" % "20.5.0"
 )

--- a/src/main/scala/com/gu/octopusthrift/models/OctopusArticle.scala
+++ b/src/main/scala/com/gu/octopusthrift/models/OctopusArticle.scala
@@ -10,34 +10,37 @@ import play.api.libs.json._
 import scala.util.{ Success, Try }
 
 /**
- * This model does not represent all fields sent by Octopus,
- * only those that will be relevant in converting to our Thrift model
- */
+  * This model does not represent all fields sent by Octopus,
+  * only those that will be relevant in converting to our Thrift model
+  */
 case class OctopusArticle(
-  id: Int,
-  filename: String,
-  for_publication: String,
-  lawyered: String,
-  object_type: String,
-  object_number: Int,
-  last_modified: String,
-  in_use_by: Option[String],
-  ischeckedout: String,
-  status: String,
-  attached_to: Option[Int],
-  on_pages: Option[String]) extends Ordered[OctopusArticle] {
+    id: Int,
+    filename: String,
+    for_publication: String,
+    lawyered: String,
+    object_type: String,
+    object_number: Int,
+    last_modified: String,
+    in_use_by: Option[String],
+    ischeckedout: String,
+    status: String,
+    attached_to: Option[Int],
+    on_pages: Option[String],
+    last_user: String
+) extends Ordered[OctopusArticle] {
 
   def lastModifiedEpoch: Long =
     TimeUnit.MILLISECONDS.toSeconds(
       DateTime
         .parse(last_modified, DateTimeFormat.forPattern("yyyyMMddHHmm").withZoneUTC())
         .withZone(DateTimeZone.UTC)
-        .getMillis)
+        .getMillis
+    )
 
   def pageNumber: Option[Long] = {
     Try(on_pages.map(_.split(',')(0).split(';')(0).toLong)) match {
       case Success(number) => number
-      case _ => None
+      case _               => None
     }
   }
 
@@ -58,7 +61,8 @@ object OctopusArticle {
       "n" -> Lawyered.Notapplicable,
       "p" -> Lawyered.Pending,
       "c" -> Lawyered.Cleared,
-      "r" -> Lawyered.Priority)
+      "r" -> Lawyered.Priority
+    )
 
     val articleStatus = Map(
       "chief sub" -> ArticleStatus.Chiefsub,
@@ -68,7 +72,8 @@ object OctopusArticle {
       "killed" -> ArticleStatus.Killed,
       "revise sub" -> ArticleStatus.Revisesub,
       "subs" -> ArticleStatus.Subs,
-      "writers" -> ArticleStatus.Writers)
+      "writers" -> ArticleStatus.Writers
+    )
 
     val isCheckedOut = Map("y" -> true, "n" -> false)
 
@@ -80,6 +85,8 @@ object OctopusArticle {
       octopusArticle.lastModifiedEpoch,
       lawyered(octopusArticle.lawyered.toLowerCase),
       articleStatus(octopusArticle.status.toLowerCase),
-      octopusArticle.filename)
+      octopusArticle.filename,
+      octopusArticle.last_user
+    )
   }
 }

--- a/src/test/scala/models/OctopusArticleSpec.scala
+++ b/src/test/scala/models/OctopusArticleSpec.scala
@@ -19,7 +19,9 @@ object ArticleTestHelpers {
       "N",
       "Writers",
       Some(1000),
-      onPages)
+      onPages,
+      "Test User"
+    )
 }
 
 class OctopusArticleSpec extends AnyWordSpec {
@@ -38,7 +40,9 @@ class OctopusArticleSpec extends AnyWordSpec {
           "N",
           "Writers",
           Some(1000),
-          Some("1"))
+          Some("1"),
+          "Test User"
+        )
 
         val thriftArticle = octopusArticle.as[Article]
 
@@ -47,6 +51,7 @@ class OctopusArticleSpec extends AnyWordSpec {
         assert(thriftArticle.lastModified == 1593000000)
         assert(thriftArticle.lawyered == Lawyered.Notapplicable)
         assert(thriftArticle.status == ArticleStatus.Writers)
+        assert(thriftArticle.lastModifiedBy == "Test User")
       }
     }
   }

--- a/src/test/scala/models/OctopusBundleSpec.scala
+++ b/src/test/scala/models/OctopusBundleSpec.scala
@@ -30,7 +30,8 @@ class OctopusBundleSpec extends AnyWordSpec with Matchers {
             "N",
             "Writers",
             Some(1000),
-            Some("1")
+            Some("1"),
+            "Test User"
           )
 
         def createBundle(article: OctopusArticle) =
@@ -69,7 +70,8 @@ class OctopusBundleSpec extends AnyWordSpec with Matchers {
           "N",
           "Writers",
           Some(1000),
-          Some("1")
+          Some("1"),
+          "Test User"
         )
 
         val octopusBundle = OctopusBundle(2345, "", "", Some("20200624"), "", Array(octopusArticle))
@@ -140,7 +142,8 @@ class OctopusBundleSpec extends AnyWordSpec with Matchers {
           "N",
           "Desk",
           Some(0),
-          Some("") // on pages
+          Some(""), // on pages
+          "Test User"
         )
         val bundle = OctopusBundle(
           15313010,

--- a/src/test/scala/services/ArticleFinderSpec.scala
+++ b/src/test/scala/services/ArticleFinderSpec.scala
@@ -21,7 +21,9 @@ class ArticleFinderSpec extends AnyWordSpec with Matchers {
       "N",
       "Writers",
       Some(1000),
-      Some("1"))
+      Some("1"),
+      "Test User"
+    )
 
   def createTestBundle(articles: Array[OctopusArticle]) = OctopusBundle(101, "", "", Some(""), "", articles)
 
@@ -86,7 +88,8 @@ class ArticleFinderSpec extends AnyWordSpec with Matchers {
         assert(
           ArticleFinder
             .findBodyText(createTestBundle(articles))
-            .contains(articleObjectTwo.copy(object_type = "Body Text")))
+            .contains(articleObjectTwo.copy(object_type = "Body Text"))
+        )
       }
       "prefer 'object_type' of Panel Text to Tabular types" in {
         val tabularArticleForWeb = createTestArticle("w", "Tabular Text", 1)


### PR DESCRIPTION
## What does this change?
https://github.com/guardian/flexible-octopus-model/pull/4 adds the `lastModifiedBy` field to the `Article` model. This represents the last user to make a modification to the content in InCopy. In the converter, we want to parse the `last_user` field received as part of the incoming JSON from Octopus into the `lastModifiedBy` field on the `Article` model.

In Workflow, we will use this in conjunction with the `status` field on the `Article` model to display information about the body text content in print.