### PR TITLE
Add Composer ID to some log messages

### DIFF
--- a/src/main/scala/com/gu/octopusthrift/services/PayloadValidator.scala
+++ b/src/main/scala/com/gu/octopusthrift/services/PayloadValidator.scala
@@ -1,6 +1,5 @@
 package com.gu.octopusthrift.services
 
-import com.gu.octopusthrift.aws.{ CustomMetrics, DeadLetterQueue, Metrics }
 import com.gu.octopusthrift.models._
 import play.api.libs.json._
 
@@ -13,7 +12,7 @@ object PayloadValidator extends Logging {
       case Success(json) =>
         json.validate[OctopusSingleBundlePayload] match {
           case JsSuccess(payload, _) => Some(payload)
-          case _: JsError => None
+          case _: JsError            => None
         }
       case _ => None
     }
@@ -24,17 +23,16 @@ object PayloadValidator extends Logging {
       case Success(json) =>
         json.validate[OctopusBundleCachePayload] match {
           case JsSuccess(payload, _) => Some(payload)
-          case _: JsError => None
+          case _: JsError            => None
         }
       case _ => None
     }
   }
 
   def isValidBundle(bundle: OctopusBundle): Boolean = {
-    logger.info(s"Validating bundle: $bundle")
+    logger.info(s"Validating bundle for ${bundle.composerId}: $bundle")
     bundle.articles.foreach(article => logger.info(s"Article: $article"))
-    logger.info(s"Body text: ${ArticleFinder.findBodyText(bundle)}")
-    logger.info(s"Composer ID: ${bundle.composerId}")
+    logger.info(s"Body text for ${bundle.composerId}: ${ArticleFinder.findBodyText(bundle)}")
     val hasComposerId = bundle.composerId.isDefined
     val hasBodyText = ArticleFinder.findBodyText(bundle).isDefined
     hasComposerId && hasBodyText


### PR DESCRIPTION
Currently, when we log out the results of `ArticleFinder.findBodyText(bundle)` it can be difficult to connect the result with the corresponding Composer content. This PR adds the Composer ID to some existing log messages, to make it easier to connect any body text Articles to the relevant Bundle when investigating logs. 