### PR TITLE
Remove `foreach` logging within `isValidBundle`

### DIFF
--- a/src/main/scala/com/gu/octopusthrift/services/PayloadValidator.scala
+++ b/src/main/scala/com/gu/octopusthrift/services/PayloadValidator.scala
@@ -31,7 +31,6 @@ object PayloadValidator extends Logging {
 
   def isValidBundle(bundle: OctopusBundle): Boolean = {
     logger.info(s"Validating bundle for ${bundle.composerId}: $bundle")
-    bundle.articles.foreach(article => logger.info(s"Article: $article"))
     logger.info(s"Body text for ${bundle.composerId}: ${ArticleFinder.findBodyText(bundle)}")
     val hasComposerId = bundle.composerId.isDefined
     val hasBodyText = ArticleFinder.findBodyText(bundle).isDefined


### PR DESCRIPTION
## What does this change?

Our converter lambda is quite noisy, accounting for almost half of our log messages in ELK during peak periods in bursts that can result in our Kinesis streams exceeding their throughputs.

<img width="1152" alt="Screenshot 2021-02-03 at 14 13 11" src="https://user-images.githubusercontent.com/7767575/106769261-a8b99800-6634-11eb-8b0a-7b560392ae78.png">

(The deeper purple is this lambda)

This PR removes a log message that accounts for about half of those messages, which should take the pressure off a little.

## How to test

The change is simple: probably easiest to deploy to PROD and measure the impact there.

## How can we measure success?

Less burst pressure, and fewer writes dropped, on our logging streams.
