### PR TITLE
Bump log4j to safe version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val awsSdkVersion = "1.11.804"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.1.0",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.3.0",
   "com.amazonaws" % "aws-java-sdk-kinesis" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
_co-authored-with: @andrew-nowak_ 

## What does this change?

Bumps log4j to a safe version. It's pulled in transitively by `aws-lambda-java-log4j2:1.1.0`.

Also adds the `dependencyTree` plugin, which gives us an easy way of querying for dependencies for this versoin of `sbt`.

## How to test

Run `sbt dependencyTree | grep log4j`. You should see that any log4j dependencies are > `2.15.x`.