### PR TITLE
Bump aws-lambda-java-log4j2 to 1.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val awsSdkVersion = "1.11.804"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.3.0",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.4.0",
   "com.amazonaws" % "aws-java-sdk-kinesis" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,


### PR DESCRIPTION
## What does this change?

Bump the aws-lambda-java-log4j2 library a second time, this version will bring in log4j2-core v2.16. Follow up to #19 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Run `sbt dependencyTree | grep log4j`. You should see that any log4j dependencies are >= 2.16.x.

