### PR TITLE
Upgrades aws-log4j2 to 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,13 @@ Logs are sent to Cloudwatch and the lambda's performance can be monitored in [Gr
 The cloud formation for these resources can be found in the [editorial-tools-platform](https://github.com/guardian/editorial-tools-platform/) repo.
 
 The thrift model can be found in the [flexible-octopus-model](https://github.com/guardian/flexible-octopus-model) repo.
+
+## Testing
+
+The project includes some basic tests for the functionality of the lambda. It is also possible to test a production environment by putting data onto the kinesis stream in base64. You can use the test resources as a starting point:
+
+Base64 encoding a file:
+`EXAMPLE=$(cat ./src/test/resources/example.json | base64)`
+
+Putting a record onto the stream:
+`aws kinesis put-record --stream-name <STREAM_NAME> --data $EXAMPLE --profile <PROFILE> --partition-key example --region <REGION>`

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ description := "AWS Lambda providing conversion between Octopus JSON and Thrift"
 
 version := "1.0"
 
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.7"
 
 scalacOptions ++= Seq(
   "-deprecation",
@@ -19,7 +19,7 @@ val awsSdkVersion = "1.11.804"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.4.0",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.0",
   "com.amazonaws" % "aws-java-sdk-kinesis" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "Editorial Tools::Octopus Conversion Lambda"
 
-assemblyMergeStrategy in assembly := {
+assembly / assemblyMergeStrategy := {
   case PathList("META-INF", xs @ _*) => MergeStrategy.discard
   case _                             => MergeStrategy.first
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.6.1


### PR DESCRIPTION
## What does this change?

This PR continues the work of #20 in light of new vulnerabilities found in version log4j2 `2.16.0`. This bump will move us to the latest `2.17.0`: https://github.com/aws/aws-lambda-java-libs/pull/295

It also updates SBT from `0.13.15` -> `1.6.1`

## How to test

Run `sbt dependencyTree | grep log4j`. You should see that any log4j dependencies are >= 2.17.x. The change should also be a no-op on CODE and PROD. 
