### PR TITLE
Upgrade aws-lambda-java-log4j2 to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The thrift model can be found in the [flexible-octopus-model](https://github.com
 The project includes some basic tests for the functionality of the lambda. It is also possible to test a production environment by putting data onto the kinesis stream in base64. You can use the test resources as a starting point:
 
 Base64 encoding a file:
-`EXAMPLE=$(cat ./src/test/resources/example.json | base64)`
+`EXAMPLE=$(cat ./src/test/resources/exampleBundleObject.json | base64)`
 
 Putting a record onto the stream:
 `aws kinesis put-record --stream-name <STREAM_NAME> --data $EXAMPLE --profile <PROFILE> --partition-key example --region <REGION>`

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val awsSdkVersion = "1.11.804"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.0",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.1",
   "com.amazonaws" % "aws-java-sdk-kinesis" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,


### PR DESCRIPTION
## What does this change?

Continuing from #21, this PR upgrades `aws-lambda-java-log4j2` to the latest: `1.5.1`.

[The fixes additional vulnerabilities by using log4j2: 1.7.1](https://github.com/aws/aws-lambda-java-libs/pull/299).

![image](https://user-images.githubusercontent.com/4633246/148078018-ad704eb1-bf37-4b28-8ae7-0d7d31706346.png)

## How to test

Do the tests passes, do the changes work on CODE?
