### PR TITLE
Build with GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           LAST_TEAMCITY_BUILD=109
           echo "BUILD_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))" >> $GITHUB_ENV
-          
+
       - uses: actions/checkout@v3
 
       - uses: actions/setup-java@v3
@@ -49,5 +49,5 @@ jobs:
           buildNumber: ${{ env.BUILD_NUMBER }}
           configPath: riff-raff.yaml
           contentDirectories: |
-            flexible-octopus-converter:
+            octopus-converter:
               - octopus-converter.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: build
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions: # required by aws-actions/configure-aws-credentials
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "adopt"
+          java-version: "8"
+          cache: "sbt"
+
+      - name: AWS Auth
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+
+      - name: Build and Test project
+        run: |
+          set -e
+          # Ensure we don't overwrite existing (Teamcity) builds.
+          LAST_TEAMCITY_BUILD=109
+          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
+          sbt clean compile test riffRaffUpload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           cache: "sbt"
 
       - name: AWS Auth
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           LAST_TEAMCITY_BUILD=109
           echo "BUILD_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,15 @@ jobs:
       contents: read
 
     steps:
+      # Seed the build number with last number from TeamCity.
+      # This env var is used by the JS, and SBT builds, and guardian/actions-riff-raff.
+      # Set the value early, rather than `buildNumberOffset` in guardian/actions-riff-raff, to ensure each usage has the same number.
+      # For some reason, it's not possible to mutate GITHUB_RUN_NUMBER, so set BUILD_NUMBER instead.
+      - name: Set BUILD_NUMBER environment variable
+        run: |
+          LAST_TEAMCITY_BUILD=109
+          echo "BUILD_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))" >> $GITHUB_ENV
+          
       - uses: actions/checkout@v3
 
       - uses: actions/setup-java@v3
@@ -31,8 +40,14 @@ jobs:
 
       - name: Build and Test project
         run: |
-          set -e
-          # Ensure we don't overwrite existing (Teamcity) builds.
-          LAST_TEAMCITY_BUILD=109
-          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          sbt clean compile test riffRaffUpload
+          sbt clean compile test assembly
+          cp target/scala*/octopus-converter.jar ./octopus-converter.jar
+
+      - uses: guardian/actions-riff-raff@v2
+        with:
+          projectName: Editorial Tools::Octopus Conversion Lambda
+          buildNumber: ${{ env.BUILD_NUMBER }}
+          configPath: riff-raff.yaml
+          contentDirectories: |
+            flexible-octopus-converter:
+              - octopus-converter.jar

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ libraryDependencies ++= Seq(
 
 // enablePlugins(RiffRaffArtifact)
 
-// assemblyJarName := s"${name.value}.jar"
+assemblyJarName := s"${name.value}.jar"
 // riffRaffPackageType := assembly.value
 // riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 // riffRaffUploadManifestBucket := Option("riffraff-builds")

--- a/build.sbt
+++ b/build.sbt
@@ -34,13 +34,8 @@ libraryDependencies ++= Seq(
   "com.twitter" %% "scrooge-core" % "20.5.0"
 )
 
-// enablePlugins(RiffRaffArtifact)
-
 assemblyJarName := s"${name.value}.jar"
-// riffRaffPackageType := assembly.value
-// riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-// riffRaffUploadManifestBucket := Option("riffraff-builds")
-// riffRaffManifestProjectName := "Editorial Tools::Octopus Conversion Lambda"
+
 
 assembly / assemblyMergeStrategy := {
   case PathList("META-INF", xs @ _*) => MergeStrategy.discard

--- a/build.sbt
+++ b/build.sbt
@@ -34,13 +34,13 @@ libraryDependencies ++= Seq(
   "com.twitter" %% "scrooge-core" % "20.5.0"
 )
 
-enablePlugins(RiffRaffArtifact)
+// enablePlugins(RiffRaffArtifact)
 
-assemblyJarName := s"${name.value}.jar"
-riffRaffPackageType := assembly.value
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
-riffRaffManifestProjectName := "Editorial Tools::Octopus Conversion Lambda"
+// assemblyJarName := s"${name.value}.jar"
+// riffRaffPackageType := assembly.value
+// riffRaffUploadArtifactBucket := Option("riffraff-artifact")
+// riffRaffUploadManifestBucket := Option("riffraff-builds")
+// riffRaffManifestProjectName := "Editorial Tools::Octopus Conversion Lambda"
 
 assembly / assemblyMergeStrategy := {
   case PathList("META-INF", xs @ _*) => MergeStrategy.discard

--- a/ci.sh
+++ b/ci.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-sbt clean compile riffRaffUpload
-

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,5 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 
-// addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
-
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
+// addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adopts GitHub Actions for CI, replacing TeamCity, and using actions-riff-raff. As far as I could tell, this just required pausing the teamcity build and adding the ci.yml file (and removing the sbt riff-raff artifact plugin)

## How to test

This branch has been built [through GHA](https://github.com/guardian/flexible-octopus-converter/actions/runs/6223345363/job/16889088759?pr=27) and [successfully deployed to CODE ](https://riffraff.gutools.co.uk/deployment/view/bde24ee5-2525-42e9-af69-411d3832f7b1) with a similar shape to previous deployments (e.g. [latest PROD](https://riffraff.gutools.co.uk/deployment/view/2c796db1-8131-4731-b0eb-5862eceb80e6))


## How can we measure success/mitigate risks?

Prod gets deployed successfully and the converter continues working. Any issues with the deployment should end up getting rolled back automatically, and we should be able to see the lambda continue performing via grafana.

## Rollout

- [X]  Pause the TeamCity build
- [ ]  Merge this PR
- [ ]  Adjust branch protection rules, requiring the GHA build to pass before merge
- [ ]  Ensure all open PRs are rebased against main to ensure their build runs

