### PR TITLE
switch to sbt-native-packager instead of sbt-assembly, hopefully sorting out logging dependency issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,7 @@ jobs:
 
       - name: Build and Test project
         run: |
-          sbt clean compile test assembly
-          cp target/scala*/octopus-converter.jar ./octopus-converter.jar
+          sbt clean compile test Universal/packageBin
 
       - uses: guardian/actions-riff-raff@v4
         with:
@@ -51,5 +50,4 @@ jobs:
           configPath: riff-raff.yaml
           contentDirectories: |
             octopus-converter:
-              - octopus-converter.jar
-              
+              - target/universal/octopus-converter.zip

--- a/build.sbt
+++ b/build.sbt
@@ -34,10 +34,7 @@ libraryDependencies ++= Seq(
   "com.twitter" %% "scrooge-core" % "20.5.0"
 )
 
-assemblyJarName := s"${name.value}.jar"
+enablePlugins(JavaAppPackaging)
 
-
-assembly / assemblyMergeStrategy := {
-  case PathList("META-INF", xs @ _*) => MergeStrategy.discard
-  case _                             => MergeStrategy.first
-}
+Universal / topLevelDirectory := None
+Universal / packageName := normalizedName.value

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
-
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")
-
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.1")

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -6,5 +6,5 @@ deployments:
     type: aws-lambda
     parameters:
       functionNames: [octopus-conversion-]
-      fileName: octopus-converter.jar
+      fileName: octopus-converter.zip
       prefixStack: false


### PR DESCRIPTION
Currently deployed versions of octopus-converter aren't doing any logging. There are some warnings at the top of log streams saying that no full version of slf4j is on the classpath, but we're adding a dependency on `slf4j-simple` which should be sufficient. I suspect some misconfiguration in our `sbt-assembly` merge strategy. 

But I hate debugging those, and the first scala lambda example I reached for uses `sbt-native-packager` instead, which I've also had good experiences with. So I converted the build steps to use that instead, which has fixed the problems - we now have logs in CODE again.