### PR TITLE
Bump tomcat-embed-core to 9.0.108

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,10 @@ libraryDependencies ++= Seq(
   "com.twitter" %% "scrooge-core" % "20.5.0"
 )
 
+dependencyOverrides ++= Seq(
+  "org.apache.tomcat.embed" % "tomcat-embed-core" % "9.0.108"
+)
+
 enablePlugins(JavaAppPackaging)
 
 Universal / topLevelDirectory := None


### PR DESCRIPTION
Fixing https://github.com/advisories/GHSA-83qj-6fr2-vhqg

## How to test

Deploy to CODE, and exercise a test event. Logs should look good.

- [x] Tested in CODE [(logs)](https://logs.gutools.co.uk/s/editorial-tools/app/r/s/C6Rfp)